### PR TITLE
Initial pass defining types for the core object types

### DIFF
--- a/src/SharedTypes.d.ts
+++ b/src/SharedTypes.d.ts
@@ -1,0 +1,5 @@
+
+// shared options between both Endpoint and client requests
+interface Options{
+	withCredentials: boolean;
+}

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,0 +1,21 @@
+interface Client {
+	delete(path: string, requestData: RequestData, requestOptions: RequestOptions): ClientResponse<any>;
+	get(path: string, requestData: RequestData, requestOptions: RequestOptions): ClientResponse<any>;
+	patch(path: string, requestData: RequestData, requestOptions: RequestOptions): ClientResponse<any>;
+	post(path: string, requestData: RequestData, requestOptions: RequestOptions): ClientResponse<any>;
+	put(path: string, requestData: RequestData, requestOptions: RequestOptions): ClientResponse<any>;
+}
+
+interface RequestData{
+	data: any;
+	param: any;
+	path: any;
+}
+
+interface RequestOptions{
+	// TODO: Need to determine the full collection of what these will be
+}
+
+interface ClientResponse<T> extends Promise<T>{
+	next: () => ClientResponse<T>;
+}

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -1,0 +1,27 @@
+
+interface Endpoint{
+	uri: string;
+	name: string;
+	methods?: Array<HttpVerbs>;
+	retry?: (func: Function) => boolean;
+	options?: Partial<EndpointOptions>;
+}
+
+interface EndpointOptions extends Partial<Options>{	
+	test: string;
+	// TODO: Need to determine the full collection of what these will be
+}
+
+enum HttpVerbs{
+	GET = "GET",
+	POST = "POST",
+	PUT = "PUT",
+	DELETE = "DELETE",
+	PATCH = "PATCH",
+}
+
+// TODO: Define the shape of these
+interface Part{
+	
+}
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,13 +3,14 @@
     "useCache": true,
   },
   "compilerOptions": {
-    "allowJs": true,
-    "jsx": "react",
+    "allowJs": false,
     "noImplicitAny": true,
     "outDir": "./build/",
     "removeComments": true,
     "sourceMap": true,
     "target": "es5",
+    "noUnusedLocals": true,
+    "declaration": true
   },
   "include": [
     "./src/**/*"


### PR DESCRIPTION
Changed some of the compiler options so that we can output typescript definition files as well when this is distributed.